### PR TITLE
wcコマンド新規追加

### DIFF
--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -52,7 +52,6 @@ def calc_max_length_per_params(word_count_params)
 end
 
 def result_output(word_count_params, string_length, option)
-  string_length = 0 if option.options.one?
   word_count_params.each do |word_count_param|
     OPTION_NAMES.each do |key|
       next if !option.options[key]
@@ -82,6 +81,11 @@ word_count_params = get_word_count_parameters(strings, file_paths)
 word_count_params << calc_total(word_count_params) if !word_count_params.one?
 
 max_length_per_params = calc_max_length_per_params(word_count_params)
-output_length = is_stdin ? TAB_WIDTH : max_length_per_params.values.max
-
+output_length = if option.options.one?
+                  0
+                elsif is_stdin
+                  TAB_WIDTH
+                else
+                  max_length_per_params.values.max
+                end
 result_output(word_count_params, output_length, option)

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -24,16 +24,14 @@ class WcOption
 end
 
 def get_word_count_parameters(strings, file_paths = [''])
-  word_count_params = []
-  strings.each_with_index do |string, i|
-    word_count_param = {}
-    word_count_param[:lines] = string.lines.count
-    word_count_param[:words] = string.split(/\s+/).size
-    word_count_param[:bytes] = string.bytesize
-    word_count_param[:file_path] = file_paths[i]
-    word_count_params << word_count_param
+  strings.map.with_index do |string, i|
+    {
+      lines: string.lines.count,
+      words: string.split(/\s+/).size,
+      bytes: string.bytesize,
+      file_path: file_paths[i]
+    }
   end
-  word_count_params
 end
 
 def calc_total(word_count_params)
@@ -68,11 +66,7 @@ option = WcOption.new
 file_paths = ARGV
 strings = []
 if file_paths.any?
-  file_paths.each do |file_path|
-    next if !File.stat(file_path).file?
-
-    strings << File.read(file_path)
-  end
+  strings = file_paths.map { |file_path| File.read(file_path) if File.stat(file_path).file? }
 elsif File.pipe?($stdin)
   strings << $stdin.read
   is_stdin = true

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -75,7 +75,7 @@ word_count_params = get_word_count_parameters(strings, file_paths)
 word_count_params << calc_total(word_count_params) if !word_count_params.one?
 
 max_length_per_params = calc_max_length_per_params(word_count_params)
-output_length = if option.options.one?
+output_length = if option.options.one? && file_paths.one?
                   0
                 elsif is_stdin
                   TAB_WIDTH

--- a/05.wc/wc.rb
+++ b/05.wc/wc.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+LOG_OPTION_JUDGE_PATTERN = /^total\s+[0-9]*\n$/
+
+class WcOption
+  require 'optparse'
+
+  def initialize
+    @options = {}
+    OptionParser.new do |opt|
+      opt.on('-c', '--bytes', 'print the byte counts') { @options[:bytes] = true }
+      opt.on('-l', '--lines', 'print the newline counts') { @options[:lines] = true }
+      opt.on('-w', '--words', 'print the word counts') { @options[:words] = true }
+      opt.parse!(ARGV)
+    end
+  end
+
+  def has?(name)
+    @options.include?(name)
+  end
+
+  def none?
+    @options.none?
+  end
+end
+
+def get_word_count_parameters(string, file_path = '')
+  word_count_param = {}
+  word_count_param[:lines] = string.lines.count.to_s
+  word_count_param[:words] = string.split(/\s+/).size.to_s
+  word_count_param[:bytes] = string.bytesize.to_s
+  word_count_param[:file_path] = file_path
+  word_count_param
+end
+
+def calc_total(word_count_params)
+  word_count_param = {}
+  word_count_param[:lines] = word_count_params.sum { |params| params[:lines].to_i }.to_s
+  word_count_param[:words] = word_count_params.sum { |params| params[:words].to_i }.to_s
+  word_count_param[:bytes] = word_count_params.sum { |params| params[:bytes].to_i }.to_s
+  word_count_param[:file_path] = 'total'
+  word_count_param
+end
+
+def calc_max_length_per_params(word_count_params)
+  max_length = {}
+  word_count_params[0].each_key do |key|
+    next if key == :file_path
+
+    tmp_length = 0
+    max_length[key] = word_count_params.each do |params|
+      tmp_length = tmp_length >= params[key].length ? tmp_length : params[key].length
+    end
+    max_length[key] = tmp_length
+  end
+  max_length
+end
+
+option = WcOption.new
+output_params = { lines: false, words: false, bytes: false }
+
+if option.none?
+  output_params = { lines: true, words: true, bytes: true }
+else
+  output_params[:lines] = true if option.has?(:lines)
+  output_params[:words] = true if option.has?(:words)
+  output_params[:bytes] = true if option.has?(:bytes)
+end
+
+file_paths = ARGV
+word_count_params = []
+if file_paths.any?
+  file_paths.each_with_index do |file_path, i|
+    next if !File.stat(file_path).file?
+
+    string = File.read(file_path)
+    word_count_params[i] = get_word_count_parameters(string, file_path)
+    word_count_params << [] if i != file_paths.size - 1
+  end
+  word_count_params << calc_total(word_count_params) if !word_count_params.one?
+
+  max_length_per_params = calc_max_length_per_params(word_count_params)
+  output_length = if output_params.values.one?
+                    max_length_per_params[output_params.key(true)]
+                  else
+                    output_length = max_length_per_params.values.max
+                  end
+elsif File.pipe?($stdin)
+  string = $stdin.read
+  word_count_params << get_word_count_parameters(string)
+  max_length_per_params = calc_max_length_per_params(word_count_params)
+
+  output_length = if output_params.values.one?
+                    max_length_per_params[output_params.key(true)]
+                  else
+                    output_length = max_length_per_params.values.max + 4
+                  end
+end
+
+word_count_params.each do |word_count_param|
+  if output_params[:lines]
+    print word_count_param[:lines].rjust(output_length)
+    print ' '
+  end
+  if output_params[:words]
+    print word_count_param[:words].rjust(output_length)
+    print ' '
+  end
+  if output_params[:bytes]
+    print word_count_param[:bytes].rjust(output_length)
+    print ' '
+  end
+  print word_count_param[:file_path] if !word_count_param[:file_path].nil?
+  puts
+end


### PR DESCRIPTION
- オプションについて
  - オプション指定なしの場合、行数、単語数、バイト数を出力する。
  - `-l`、`--lines`オプションを指定すると行数を出力する。
  - `c`、`--bytes`オプションを指定するとバイト数を出力する。
  - `w`、`--words`オプションを指定すると、単語数を表示する。

- 出力について 出力順は行数、単語数、バイト数、ファイルパス(もしくは`total`)の順で出力する。

  - 出力するパラメータが1つの場合 
    出力するパラメータの値の最大桁数で表示する。

  - 出力するパラメータが複数の場合
    表示パラメータではなく全パラメータ(行数、単語数、Byte数)の最大桁数で表示する。

  - パイプラインで文字列を受け取った場合
    各パラメータの感覚は半角スペース4つ空ける。

  - コマンドライン引数でファイルパスを指定された場合 
    各パラメータの間隔は半角スペース1つ空ける。 指定されたファイルパスを表示する。
    複数のファイルパスを指定された場合はそれぞれの合計値も出力する。